### PR TITLE
crs-2744-add-reason-for-missing-information

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsidentifyremandperiodsapi/relevantremand/entity/IdentifyRemandDecision.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsidentifyremandperiodsapi/relevantremand/entity/IdentifyRemandDecision.kt
@@ -21,6 +21,8 @@ data class IdentifyRemandDecision(
 
   val rejectComment: String? = null,
 
+  val reasonForMissingInformation: String? = null,
+
   val decisionAt: LocalDateTime = LocalDateTime.now(),
 
   val decisionByUsername: String = "",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsidentifyremandperiodsapi/relevantremand/model/IdentifyRemandDecisionDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsidentifyremandperiodsapi/relevantremand/model/IdentifyRemandDecisionDto.kt
@@ -5,6 +5,7 @@ import java.time.LocalDateTime
 data class IdentifyRemandDecisionDto(
   val accepted: Boolean,
   val rejectComment: String?,
+  val reasonForMissingInformation: String?,
   val options: RemandCalculationRequestOptions? = null,
 
   // View fields

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsidentifyremandperiodsapi/relevantremand/service/FindReleaseDateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsidentifyremandperiodsapi/relevantremand/service/FindReleaseDateService.kt
@@ -16,7 +16,7 @@ import java.time.LocalDate
 class FindReleaseDateService(
   private val historicReleaseDateService: FindHistoricReleaseDateService,
   private val calculateReleaseDateService: CalculateReleaseDateService,
-  @Value("\${primary-release-date-provider:HISTORIC}") private val primaryReleaseDateService: String = "HISTORIC",
+  @param:Value("\${primary-release-date-provider:HISTORIC}") private val primaryReleaseDateService: String = "HISTORIC",
 ) {
   private val secondaryReleaseDateService: String = if (primaryReleaseDateService == "HISTORIC") "CRDS" else "HISTORIC"
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsidentifyremandperiodsapi/relevantremand/service/IdentifyRemandDecisionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsidentifyremandperiodsapi/relevantremand/service/IdentifyRemandDecisionService.kt
@@ -58,6 +58,7 @@ class IdentifyRemandDecisionService(
       IdentifyRemandDecision(
         accepted = decision.accepted,
         rejectComment = if (!decision.accepted) decision.rejectComment else null,
+        reasonForMissingInformation = decision.reasonForMissingInformation,
         person = person,
         days = days,
         decisionByUsername = getCurrentAuthentication().principal,
@@ -96,6 +97,7 @@ class IdentifyRemandDecisionService(
     return IdentifyRemandDecisionDto(
       accepted = decision.accepted,
       rejectComment = decision.rejectComment,
+      reasonForMissingInformation = decision.reasonForMissingInformation,
       days = decision.days,
       decisionOn = decision.decisionAt,
       decisionBy = decision.decisionByUsername,

--- a/src/main/resources/migration/common/V7__Add_reason_for_missing_information.sql
+++ b/src/main/resources/migration/common/V7__Add_reason_for_missing_information.sql
@@ -1,0 +1,1 @@
+ALTER TABLE identify_remand_decision ADD COLUMN reason_for_missing_information varchar default null;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsidentifyremandperiodsapi/relevantremand/controller/RelevantRemandControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsidentifyremandperiodsapi/relevantremand/controller/RelevantRemandControllerIntTest.kt
@@ -249,7 +249,7 @@ class RelevantRemandControllerIntTest : IntegrationTestBase() {
   @Test
   fun `Save reject decision with reason for missing information`() {
     val options = RemandCalculationRequestOptions(
-      userSelections = emptyList()
+      userSelections = emptyList(),
     )
     webTestClient.post()
       .uri("/relevant-remand/${PrisonApiExtension.MULTIPLE_OFFENCES_PRISONER}/decision")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsidentifyremandperiodsapi/relevantremand/controller/RelevantRemandControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsidentifyremandperiodsapi/relevantremand/controller/RelevantRemandControllerIntTest.kt
@@ -219,6 +219,7 @@ class RelevantRemandControllerIntTest : IntegrationTestBase() {
         IdentifyRemandDecisionDto(
           accepted = false,
           rejectComment = "This is not correct",
+          reasonForMissingInformation = null,
           options = options,
         ),
       )
@@ -231,6 +232,46 @@ class RelevantRemandControllerIntTest : IntegrationTestBase() {
     assertThat(result!!.decisionByUsername).isEqualTo("test-client")
     assertThat(result.accepted).isFalse
     assertThat(result.rejectComment).isEqualTo("This is not correct")
+    assertThat(result.days).isEqualTo(448)
+
+    val getResult = webTestClient.get()
+      .uri("/relevant-remand/${PrisonApiExtension.MULTIPLE_OFFENCES_PRISONER}/decision")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisationRemandToolUser())
+      .exchange()
+      .expectStatus().isOk
+      .returnResult(IdentifyRemandDecisionDto::class.java).responseBody.blockFirst()!!
+
+    assertThat(getResult.decisionByPrisonDescription).isEqualTo("Birmingham Prison")
+    assertThat(getResult.options).isEqualTo(RemandCalculationRequestOptions())
+  }
+
+  @Test
+  fun `Save reject decision with reason for missing information`() {
+    val options = RemandCalculationRequestOptions(
+      userSelections = emptyList()
+    )
+    webTestClient.post()
+      .uri("/relevant-remand/${PrisonApiExtension.MULTIPLE_OFFENCES_PRISONER}/decision")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(
+        IdentifyRemandDecisionDto(
+          accepted = false,
+          rejectComment = null,
+          reasonForMissingInformation = "missing NOMIS data",
+          options = options,
+        ),
+      )
+      .headers(setAuthorisationRemandToolUser())
+      .exchange()
+      .expectStatus().isCreated
+
+    val result = decisionRepository.findFirstByPersonOrderByDecisionAtDesc(PrisonApiExtension.MULTIPLE_OFFENCES_PRISONER)
+
+    assertThat(result!!.decisionByUsername).isEqualTo("test-client")
+    assertThat(result.accepted).isFalse
+    assertThat(result.reasonForMissingInformation).isEqualTo("missing NOMIS data")
     assertThat(result.days).isEqualTo(448)
 
     val getResult = webTestClient.get()
@@ -259,6 +300,7 @@ class RelevantRemandControllerIntTest : IntegrationTestBase() {
         IdentifyRemandDecisionDto(
           accepted = true,
           rejectComment = null,
+          reasonForMissingInformation = null,
           options = options,
         ),
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsidentifyremandperiodsapi/relevantremand/service/ThingsToDoServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsidentifyremandperiodsapi/relevantremand/service/ThingsToDoServiceTest.kt
@@ -335,6 +335,7 @@ class ThingsToDoServiceTest {
       options = nonDefaultOptions,
       accepted = false,
       rejectComment = "Not right",
+      reasonForMissingInformation = null,
       decisionOn = LocalDateTime.of(2024, 6, 1, 10, 0, 0),
       decisionByPrisonId = "LEI",
       days = 32,
@@ -343,6 +344,7 @@ class ThingsToDoServiceTest {
       options = nonDefaultOptions,
       accepted = true,
       rejectComment = null,
+      reasonForMissingInformation = null,
       days = 32,
     )
     private val unusedDeductionsCalculatedStatus = UnusedDeductionsCalculationResultDto(


### PR DESCRIPTION
Add reason for missing information for identify remand decision. Value is entered when a user bypasses validation warnings for missing NOMIS data.